### PR TITLE
Document intuitive decisions for upcoming launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,21 +28,21 @@ get started:
 We aim for:
 
 - A conversational, tech-savvy tone.
-- Humor that feels natural — not forced.
+- Humour that feels natural — not forced.
 - Practical takeaways, real-world war stories, and honest reflections.
 
 Posts should feel like advice you'd give a peer over coffee (or debugging logs).
 
 ### 📐 Style and Quality
 
-We plan to adopt [Vale](https://vale.sh) for automated style enforcement. This will help us maintain consistent tone,
+We plan to adopt [Vale](https://vale.sh) for automated style enforcement. This will help us maintain a consistent tone,
 clarity, and formatting — but it’s not yet wired into the pipeline.
 
 In the meantime, we encourage:
 
 - **Using GPTs to help shape and refine drafts.** Whether brainstorming an intro, cleaning up clunky phrases, or
   rewording a technical explanation — AI tools can help emit more polished, uniform English.
-- Prompts should preserve Markdown and Hugo syntax, and maintain our preferred tone: thoughtful, punchy, and friendly.
+- Prompts should preserve Markdown and Hugo syntax and maintain our preferred tone: thoughtful, punchy, and friendly.
 - When in doubt, ask another author to review. We're here to help each other write better.
 
 > [!TIP]
@@ -53,7 +53,7 @@ In the meantime, we encourage:
 We're working toward a more complete authoring guide, pre-publish checklists, and automation for preview environments.
 Until then, keep things simple, and when in doubt — write it down.
 
-Stay curious, write often, and don’t forget to laugh at your own bugs.
+Stay curious, write often, and remember to laugh at your own bugs.
 
 — The Bytes of our Lives Team 🧵
 

--- a/docs/decisions/03-hugo-site-generator.md
+++ b/docs/decisions/03-hugo-site-generator.md
@@ -1,0 +1,65 @@
+# Hugo as Our Static-Site Generator
+
+With our blog workflow firmly rooted in GitOps, the next critical choice is selecting the right static-site generator.
+We need a tool that matches our Git-first approach, offers simplicity, facilitates local authoring and customisation,
+and fits our team's technical preferences.
+
+## Context
+
+We evaluated several popular static-site generators:
+
+- **Hugo:** A Go-based static-site generator known for its incredible build speed, simplicity, powerful content
+  organisation, native Markdown support, rich theme ecosystem, and excellent local authoring experience.
+- **Next.js:** A powerful React-based framework offering hybrid static-site and server-side rendering, suitable for
+  dynamic sites but introducing more complexity in authoring and styling.
+- **Gatsby:** React-based static-site generator with a rich plugin ecosystem and GraphQL integration, but higher
+  complexity and slower local development experiences.
+- **Jekyll:** Ruby-based static-site generator popular with GitHub Pages, but slower builds and limited extensibility
+  for complex themes and customisations.
+
+Our key criteria were:
+
+- **Local Authoring Experience:** Smooth local editing with live hot reload previews for instant feedback.
+- **Technical Familiarity:** Tools that align closely with our team's existing skills in Go and Markdown.
+- **Simplicity:** Minimal configuration, intuitive structure, and fewer moving parts.
+- **Customisation and Themes:** Easy separation between content (articles, posts) and their presentation (layouts,
+  themes), enabling flexible styling and metadata (e.g. is-draft, dates, keywords, etc.).
+- **Advanced Integrations:** We want to be able to add things like client-side search and user analytics (e.g. Google
+  Analytics or Plausible) with minimal configuration and no need for a complex front-end framework.
+- **Content Organisation**: Our content should be structured in a way that supports filtering by tags, grouping into
+  series, and surfacing related or featured posts without requiring additional build logic or database-like complexity.
+
+## Decision
+
+We choose **Hugo** as our static-site generator.
+
+### Rationale
+
+- **Fast Local Development:** Hugo provides rapid local authoring with built-in live previews, enhancing immediate
+  feedback during content creation.
+- **Content-Presentation Decoupling:** Hugo naturally separates content organisation from layout and presentation,
+  simplifying content management and future theming changes.
+- **Rich Theming Support:** A large ecosystem of existing themes and straightforward customisation meets our design and
+  branding needs without extensive front-end complexity.
+- **Client-Side Enhancements:** Hugo easily integrates with common client-side enhancements like _Lunr.js_ for search
+  and _Google Analytics_ for monitoring engagement.
+- **Shortcodes for Custom Content Blocks**: Hugo provides a simple way to include reusable HTML snippets inside Markdown
+  without actually writing raw HTML. This helps us keep our content clean and readable while still supporting custom
+  elements like callouts, warnings, or series navigation.
+
+## Consequences
+
+- Our team experiences a streamlined authoring process with rapid previews and minimal setup.
+- Hugo reinforces our Go-based tooling preference, making custom enhancements straightforward.
+- Advanced dynamic features available out-of-the-box with frameworks like Next.js require external solutions or plugins
+  in Hugo.
+- A later decision record will address our deployment approach, choosing between platforms like GitHub Actions,
+  Vercel, Netlify, or similar services.
+
+## Revisit When
+
+- Our requirements evolve significantly towards dynamic or interactive client-side functionalities that Hugo struggles
+  to support.
+- Authoring or content organisation needs to become overly complex, making React-based solutions like Next.js or Gatsby
+  potentially more attractive.
+- The available theme ecosystem or ease of customisation in Hugo no longer meets our design and branding ambitions.

--- a/docs/decisions/04-hosting-on-github-pages.md
+++ b/docs/decisions/04-hosting-on-github-pages.md
@@ -1,0 +1,59 @@
+# GitHub Pages for Blog Hosting (Initially)
+
+With Hugo selected for static-site generation, our next key decision was identifying the right hosting solution. We
+needed a straightforward, low-maintenance hosting platform that aligns with our Git-first workflow and avoids
+introducing unnecessary complexity.
+
+## Context
+
+We explored several options for hosting static websites:
+
+- **GitHub Pages:** Built directly into GitHub, offering simple, no-frills static-site hosting tightly integrated with
+  our existing GitOps workflow.
+- **Cloud Storage (e.g. AWS S3, Google Cloud Storage, Azure Blob Storage):** Reliable, highly customisable hosting
+  platforms, but requiring additional configuration and complexity (DNS, CDN, SSL handling).
+- **Netlify/Vercel:** Specialised hosting services offering advanced features like automatic previews and integrated
+  build pipelines, but adding an external dependency and additional complexity to our stack.
+
+Our practical criteria for hosting were:
+
+- **Custom Domain Support**: We want our blog to live at a branded domain (e.g. blog.com) rather than a generic
+  subdomain provided by the hosting platform.
+- **Unified Management:** We reside on GitHub for all our workflows. Switching context to another platform introduces
+  unnecessary complexity.
+- **Minimal Overhead:** We prefer a simple setup without complex configurations, reducing ongoing maintenance tasks.
+- **Familiarity:** Code-defined hosting setup, avoiding hidden complexity or proprietary configurations.
+
+## Decision
+
+We chose **GitHub Pages** as our initial hosting platform.
+
+### Rationale
+
+- **Free Hosting**: GitHub Pages allows us to host our site without any cost, making it a practical choice while we're
+  still growing the blog and avoiding unnecessary expenses.
+- **Unified Workflow:** GitHub Pages keeps hosting directly within GitHub, simplifying management and eliminating the
+  context switching required by external services.
+- **Ease of Use:** Minimal setup is required because GitHub Pages isn't configurable. Simply generate the static site
+  and call the official action to deploy it.
+- **Familiarity:** We are familiar with GitHub Pages (i.e. their documentation and setup), meaning fewer surprises and
+  easier debugging.
+- **Minimal Dependencies:** Staying on GitHub reduces external dependencies and vendor lock-in, keeping our stack lean
+  and easy to manage.
+
+## Consequences
+
+- We benefit from a straightforward and low-overhead publishing process, simplifying maintenance and management.
+- Advanced capabilities provided by dedicated static hosting services (like automated preview environments or custom
+  redirects) may require manual workarounds or additional tooling.
+- Future requirements such as detailed analytics, redirects, or advanced CDN features may force us to migrate completely
+  to dedicated hosting solutions like Netlify or cloud storage.
+
+## Revisit When
+
+- We outgrow the simplicity of GitHub Pages due to increasing needs for customisation, redirects, security headers, or
+  advanced CDN and caching features.
+- The benefits of dedicated static hosting platforms significantly outweigh our current preference for simplicity and
+  unified GitHub management (e.g. branch previews).
+- Reliability or performance concerns arise with GitHub Pages, negatively impacting our blog's availability or user
+  experience.

--- a/docs/decisions/05-style-linting-with-vale.md
+++ b/docs/decisions/05-style-linting-with-vale.md
@@ -1,0 +1,56 @@
+# Enforce Consistent Writing Style with Vale
+
+As our blog grows, we foresee that maintaining consistency across posts, especially with multiple authors, will
+become increasingly important. We want an automated, lightweight way to preserve a unified voice without sacrificing
+author freedom or introducing cumbersome processes.
+
+## Context
+
+Our Hugo-based blog uses Markdown extensively and is maintained by a small, async team of trusted, tech-savvy authors.
+From the outset, we recognise that inconsistencies in tone, style, and phrasing are likely to emerge.
+
+We explored several options to proactively enforce consistency:
+
+- **Manual reviews:** Effective but tedious and inconsistent.
+- **LanguageTool and Grammarly:** Powerful grammar-checking but lacking deep integration with Markdown and Hugo
+  shortcodes. Though privacy isn't much of a concern, the limited configurability is a troubling issue.
+- **Custom scripts or CI pipelines:** Possible but potentially fragile and complex.
+- **Vale:** An open-source, syntax-aware linter for prose that supports Markdown and is highly customisable with
+  static files of rules.
+
+We want a tool that integrates seamlessly into our existing Git-based workflow, runs locally and via CI, is easily
+customisable without becoming burdensome — and ideally comes with fair, opinionated presets that reduce setup friction.
+
+## Decision
+
+We are adopting **Vale** as our primary tool to enforce a consistent writing style across the blog.
+
+Vale will run locally as a pre-commit hook and in GitHub Actions for CI checks. Configuration files will live in the
+`.vale/` directory of the repository, with rules tailored specifically for our tone: conversational, witty, and
+tech-savvy.
+
+### Rationale
+
+- Vale natively supports Markdown, making it ideal for our Hugo-based workflow. It can be configured to ignore
+  Hugo-specific syntax like shortcodes and custom Markdown blocks, ensuring it doesn’t lint where it shouldn't.
+- It’s fast, straightforward to customise, and runs offline.
+- Integrating Vale into GitHub Actions is straightforward, providing immediate, actionable feedback.
+- Alternatives like LanguageTool or Grammarly are rejected due to integration complexity and configurability.
+
+## Consequences
+
+- Authors will get immediate feedback on style issues before committing, reducing manual review overhead.
+- We'll maintain a consistent voice without restricting author creativity.
+- There is a small upfront and ongoing effort required to tune Vale rules and keep them relevant to our evolving style.
+- While Vale runs in CI and provides style enforcement, the final responsibility for clarity and polish lies with
+  authors. CI may block certain style violations, but it won't catch issues of tone, grammar, or coherence.
+- At this stage, we’re not integrating grammar-focused tools like LanguageTool or Grammarly into CI. For clarity and
+  overall writing quality, authors are encouraged to use LLM-powered tools like GitHub Copilot and Gemini during
+  drafting and review.
+
+## Revisit When
+
+- Vale rules require frequent, extensive maintenance that outweighs their benefit.
+- We introduce new tools or integrations that handle both grammar and style more seamlessly and comprehensively.
+- Our workflow significantly changes—for example, adopting a CMS or other external authoring tool incompatible with
+  Vale.

--- a/docs/decisions/06-publishing-continuously.md
+++ b/docs/decisions/06-publishing-continuously.md
@@ -1,0 +1,82 @@
+# Publish Continuously from the `main` Branch (with Meaningful Release Tags)
+
+We've chosen Hugo to power our blog, and we want a smooth, low-friction way to publish content frequently and
+collaboratively. Yet we also feel it's important to highlight significant milestones and changes clearly; whether it's
+our initial launch, a major theme refresh, or quarterly summaries. Balancing everyday simplicity with meaningful
+traceability isn't trivial.
+
+## Context
+
+Publishing strategies fall broadly into two camps: continuous frictionless deployments directly from the `main` branch,
+or carefully versioned releases tied explicitly to Git tags. The continuous approach is agile and low overhead, ideal
+for fast, iterative publishing—perfect for a blog. However, it lacks clear markers for significant updates, making it
+harder for future authors or maintainers to quickly grasp major project milestones.
+
+The tagged-release method (using GitHub Releases) provides clear, documented checkpoints and nice UI features like
+built-in changelogs. However, requiring manual tags for every publication can feel heavy, slow down authors, and
+discourage regular content updates. We wanted something in between: a solution that enables frictionless daily
+publishing while clearly marking important milestones.
+
+Moreover, tags are any arbitrary Git refs, so we would like to come up with some guidelines for tagging milestones in
+this project.
+
+## Decision
+
+We will adopt a hybrid publishing workflow:
+
+- **Continuous deployment from `main`**: Every merge into `main` automatically triggers a Hugo build and deploys to our
+  hosting (currently GitHub Pages). Routine articles go live immediately.
+- **Explicit milestone tags**: Occasionally, we'll manually create Git tags and GitHub Releases for meaningful
+  milestones. These tagged releases might reflect major blog events like initial launch (`Launch`), significant theme
+  changes, or seasonal round-ups (`New theme 🎭`, `2025 Wrapped`, etc.).
+
+Releases will be tagged and named without a schema at this point. For example, the upcoming release marking the launch
+of the blog may be tagged as `launch` or `milestone/first-launch`. This decision doesn’t lay any restriction on other
+tags while offering a format for [tagging milestones](#tagging-milestones).
+
+### Rationale
+
+This hybrid approach offers the best of both worlds:
+
+- Continuous publishing maintains agility, allowing authors to quickly share posts and updates without added overhead.
+- Explicit milestone tags give us clear markers, helpful changelogs, and a structured history for significant updates,
+  facilitating better long-term maintenance and clarity.
+
+### Tagging Milestones
+
+To distinguish formal content milestones from routine development history, we tag releases using the `milestone/NN-slug`
+format. The `milestone/` prefix clearly scopes the reference, and the zero-padded sequence number maintains logical and
+lexicographical order, that is immediately obvious to viewers. Richer context is provided in the associated GitHub
+Release notes, keeping tags clean and durable.
+
+Why does this work so well?
+
+- 🔢 Establishes chronological order.
+- 🧠 Human-readable without being noisy or bloated.
+- 🔖 Distinguishes milestones from regular branch names or other Git tags.
+- 🧹 GitHub Release notes carry the rich context — the tag stays clean.
+
+For example:
+
+| Tag                           | Meaning                   |
+|-------------------------------|---------------------------|
+| `milestone/01-initial-launch` | First live deployment     |
+| `milestone/02-theme-redesign` | New theme rollout         |
+| `milestone/03-50th-post`      | Celebrating 50 posts      |
+| `milestone/04-Q3-wrapup`      | Quarterly retrospective   |
+| `milestone/05-2025-wrapped`   | End of year retrospective |
+
+## Consequences
+
+- Authors benefit from the ease of publishing regularly, reducing friction in everyday blogging.
+- Maintainers can easily identify and communicate major site milestones through GitHub Releases, improving traceability
+  and historical context.
+- We introduce a small manual overhead: team members must remember to occasionally tag meaningful releases.
+- Without clear discipline, there is a slight risk of milestone tagging becoming inconsistent or overlooked.
+
+## Revisit When
+
+- Authors frequently skip milestone tagging, resulting in outdated or confusing historical context in GitHub Releases.
+- Milestones become so frequent or infrequent that their value as meaningful checkpoints diminishes significantly.
+- We decide to switch hosting or tooling that makes either continuous deployment or manual tagging notably easier or
+  harder.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -19,7 +19,7 @@ give us a clear trail when we want to revisit or improve something later.
 
 ## Authoring New Decisions
 
-All decisions follow the format and tone defined in [the first decision record](./01-decision-records). When you’re
+All decisions follow the format and tone defined in [the first decision record](./01-decision-records.md). When you’re
 ready to add a new decision, create a new Markdown file in this folder and name it something like
 `00-kebab-case-identifier.md`. Do read the referenced decision record first, as it contains important instructions on
 how to write these documents.
@@ -38,4 +38,4 @@ keep track of what’s been documented and makes it easier to find specific deci
 
 This section should be updated whenever a new decision file is added:
 
-1. [Capture project decisions using Markdown-based records](./01-decision-records)
+1. [Capture project decisions using Markdown-based records](./01-decision-records.md)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -43,3 +43,4 @@ This section should be updated whenever a new decision file is added:
 3. [Hugo as Our Static-Site Generator](./03-hugo-site-generator.md)
 4. [GitHub Pages for Blog Hosting (Initially)](./04-hosting-on-github-pages.md)
 5. [Enforce Consistent Writing Style with Vale](./05-style-linting-with-vale.md)
+6. [Publish Continuously from the `main` Branch (with Meaningful Release Tags)](./06-publishing-continuously.md)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -42,3 +42,4 @@ This section should be updated whenever a new decision file is added:
 2. [Power Our Blog Using a Static-Site Generator](./02-git-first-blogging.md)
 3. [Hugo as Our Static-Site Generator](./03-hugo-site-generator.md)
 4. [GitHub Pages for Blog Hosting (Initially)](./04-hosting-on-github-pages.md)
+5. [Enforce Consistent Writing Style with Vale](./05-style-linting-with-vale.md)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -3,7 +3,7 @@
 This folder contains lightweight, Markdown-based records of important decisions we've made about how we build, publish,
 and maintain this blog.
 
-These documents are written for **future teammates and maintainers** — including our future selves—so we can understand
+These documents are written for **future teammates and maintainers**, including our future selves, so we can understand
 the reasoning behind decisions that aren’t obvious from code or config alone.
 
 They’re not formal, they’re not bureaucratic, and they don’t require ceremony. Just enough structure to stay consistent
@@ -24,8 +24,8 @@ ready to add a new decision, create a new Markdown file in this folder and name 
 `00-kebab-case-identifier.md`. Do read the referenced decision record first, as it contains important instructions on
 how to write these documents.
 
-If you're drafting a new record or back-filling an old one, you can use the [ChatGPT prompt][chatgpt-prompt] below to
-generate a clean starting point. Just drop it into the chat with the relevant context or conversation.
+If you're drafting a new record or backfilling an old one, you can use [this ChatGPT prompt][chatgpt-prompt] to generate
+a clean starting point; it is ready to be dropped into a chat with the relevant context or conversation.
 
 [chatgpt-prompt]: prompts.md#extracting-a-decision-record
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -41,3 +41,4 @@ This section should be updated whenever a new decision file is added:
 1. [Capture project decisions using Markdown-based records](./01-decision-records.md)
 2. [Power Our Blog Using a Static-Site Generator](./02-git-first-blogging.md)
 3. [Hugo as Our Static-Site Generator](./03-hugo-site-generator.md)
+4. [GitHub Pages for Blog Hosting (Initially)](./04-hosting-on-github-pages.md)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -40,3 +40,4 @@ This section should be updated whenever a new decision file is added:
 
 1. [Capture project decisions using Markdown-based records](./01-decision-records.md)
 2. [Power Our Blog Using a Static-Site Generator](./02-git-first-blogging.md)
+3. [Hugo as Our Static-Site Generator](./03-hugo-site-generator.md)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -39,3 +39,4 @@ keep track of what’s been documented and makes it easier to find specific deci
 This section should be updated whenever a new decision file is added:
 
 1. [Capture project decisions using Markdown-based records](./01-decision-records.md)
+2. [Power Our Blog Using a Static-Site Generator](./02-git-first-blogging.md)


### PR DESCRIPTION
This pull-request includes the following changes:
- Documented decisions on:
  - Continuous publishing approach for tagging milestones.
  - Using Vale as the prose linter for improved consistency.
  - Selecting GitHub Pages as the hosting platform for its simplicity.
  - Adopting Hugo as the static-site generator due to team familiarity.
- Updated and fixed the decision index to include a previously omitted ADR.
- Fixed broken links in decisions' README.
- Addressed Grazie-reported comments on docs.

This pull-request does not yet contain the implementation of those decisions. While typically a PR would contain a single decision with its realisation into code, this PR backfills decisions that were already made.