### PR TITLE
Continuously deploy the Hugo-based blog to GitHub Pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,74 @@
+# Sample workflow for building and deploying a Hugo site to GitHub Pages
+name: Deploy Hugo site to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+# Default to bash
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.128.0
+    steps:
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+      - name: Install Dart Sass
+        run: sudo snap install dart-sass
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Install Node.js dependencies
+        run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
+      - name: Build with Hugo
+        env:
+          HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
+          HUGO_ENVIRONMENT: production
+        run: |
+          hugo \
+            --minify \
+            --baseURL "${{ steps.pages.outputs.base_url }}/"
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./public
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,6 +56,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive   # Ensures theme assets are available during build.
+          fetch-depth: 0          # Full history is needed for accurate versioning (e.g. .GitInfo, .LastMod, enableGitInfo).
 
       - name: Setup GitHub Pages
         id: pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,73 +1,98 @@
-# Sample workflow for building and deploying a Hugo site to GitHub Pages
-name: Deploy Hugo site to Pages
+# ───────────────────
+# Hugo Site Deployment
+# ───────────────────
+# Automating the build and deployment process ensures consistent publishing
+# while eliminating manual steps that could introduce errors.
+name: Deploy Hugo Site to GitHub Pages
 
+# Triggers
+# ───────────────────
 on:
-  # Runs on pushes targeting the default branch
   push:
-    branches: ["main"]
+    branches: ["main"]  # The main branch contains production-ready content only.
+  workflow_dispatch:    # Enables manual deployments for testing or emergency fixes.
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# Permissions
+# ───────────────────
+# GitHub's principle of least privilege applied to token permissions.
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: read        # Source access needed but no content modification required.
+  pages: write          # Required to publish to GitHub Pages destination.
+  id-token: write       # Enables secure deployment without storing credentials.
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+# Concurrency
+# ───────────────────
+# Prevents race conditions with multiple deploys changing site URL references.
+# Allowing in-progress runs to finish avoids broken partial deploys of live content.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
-# Default to bash
+# Ensures Hugo commands and shell expansions work identically across Linux/macOS runners.
+# Avoids PowerShell inconsistencies with variable expansion in Windows runners.
 defaults:
   run:
     shell: bash
 
+# Jobs
+# ───────────────────
 jobs:
-  # Build job
+  # Build Job
+  # ───────────────
+  # Pre-building static assets offloads compute resources from the deployment environment
+  # and allows for high-fidelity testing of build output before publishing.
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.128.0
+      HUGO_VERSION: 0.128.0  # Pinned for reproducible builds.
     steps:
       - name: Install Hugo CLI
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+      
       - name: Install Dart Sass
         run: sudo snap install dart-sass
-      - name: Checkout
+      
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: recursive
-      - name: Setup Pages
+          submodules: recursive  # Ensures theme assets are available during build.
+      
+      - name: Setup GitHub Pages
         id: pages
         uses: actions/configure-pages@v5
+      
       - name: Install Node.js dependencies
+        # Only attempts installation if package files exist - prevents errors on pure Hugo sites.
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
-      - name: Build with Hugo
+      
+      - name: Build Hugo site
         env:
+          # Using runner.temp ensures cache isolation between workflow runs.
           HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
+          # Production builds enable optimizations and proper environment-specific features.
           HUGO_ENVIRONMENT: production
         run: |
           hugo \
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
-      - name: Upload artifact
+
+      - name: Upload site artifacts
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./public
+          path: ./public          # Hugo outputs the static site to the 'public' directory.
 
-  # Deployment job
+  # Deployment Job
+  # ───────────────
+  # Isolated deployment stage for security boundary and deployment tracking.
   deploy:
     environment:
       name: github-pages
+      # Dynamic URL ensures links remain correct if the repository or branch changes.
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
+    needs: build        # Only deploy successful builds.
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,23 +44,15 @@ jobs:
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
-      
-      - name: Install Dart Sass
-        run: sudo snap install dart-sass
-      
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive  # Ensures theme assets are available during build.
-      
+
       - name: Setup GitHub Pages
         id: pages
         uses: actions/configure-pages@v5
-      
-      - name: Install Node.js dependencies
-        # Only attempts installation if package files exist - prevents errors on pure Hugo sites.
-        run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
-      
+
       - name: Build Hugo site
         env:
           # Using runner.temp ensures cache isolation between workflow runs.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,23 +33,27 @@ jobs:
   # ───────────────
   # Pre-building static assets offloads compute resources from the deployment environment
   # and allows for high-fidelity testing of build output before publishing.
+  #
+  # See <https://gohugo.io/installation/linux/#prerequisites> for Hugo installation details.
   build:
     permissions:
       contents: read    # Only needs read access to checkout repository contents.
     runs-on: ubuntu-latest
-    env:
-      HUGO_VERSION: 0.128.0  # Pinned for reproducible builds.
     steps:
-      - name: Install Hugo CLI
-        run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
-
       # Hugo requires Go to manage its modules (themes, plugins, and the likes).
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: 'stable'    # Always use the latest stable version of Go.
+
+      - name: Install Hugo CLI
+        run: |
+          LATEST_TAG=$(gh release view --repo gohugoio/hugo --json tagName -q .tagName)
+          echo "Installing Hugo version $LATEST_TAG"
+          ASSET_NAME="hugo_extended_${LATEST_TAG#v}_linux-amd64.deb"
+          ASSET_URL=$(gh release view "$LATEST_TAG" --repo gohugoio/hugo --json assets -q ".assets[] | select(.name==\"$ASSET_NAME\") | .url")
+          wget -O ${{ runner.temp }}/hugo.deb "$ASSET_URL"
+          sudo dpkg -i ${{ runner.temp }}/hugo.deb
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,14 +12,6 @@ on:
     branches: ["main"]  # The main branch contains production-ready content only.
   workflow_dispatch:    # Enables manual deployments for testing or emergency fixes.
 
-# Permissions
-# ───────────────────
-# GitHub's principle of least privilege applied to token permissions.
-permissions:
-  contents: read        # Source access needed but no content modification required.
-  pages: write          # Required to publish to GitHub Pages destination.
-  id-token: write       # Enables secure deployment without storing credentials.
-
 # Concurrency
 # ───────────────────
 # Prevents race conditions with multiple deploys changing site URL references.
@@ -42,6 +34,8 @@ jobs:
   # Pre-building static assets offloads compute resources from the deployment environment
   # and allows for high-fidelity testing of build output before publishing.
   build:
+    permissions:
+      contents: read    # Only needs read access to checkout repository contents.
     runs-on: ubuntu-latest
     env:
       HUGO_VERSION: 0.128.0  # Pinned for reproducible builds.
@@ -87,6 +81,9 @@ jobs:
   # ───────────────
   # Isolated deployment stage for security boundary and deployment tracking.
   deploy:
+    permissions:
+      pages: write      # Required for publishing to GitHub Pages.
+      id-token: write   # Required for interacting with GitHub deployments.
     environment:
       name: github-pages
       # Dynamic URL ensures links remain correct if the repository or branch changes.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,6 +44,13 @@ jobs:
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+
+      # Hugo requires Go to manage its modules (themes, plugins, and the likes).
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'    # Always use the latest stable version of Go.
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,8 +33,6 @@ jobs:
   # ───────────────
   # Pre-building static assets offloads compute resources from the deployment environment
   # and allows for high-fidelity testing of build output before publishing.
-  #
-  # See <https://gohugo.io/installation/linux/#prerequisites> for Hugo installation details.
   build:
     permissions:
       contents: read    # Only needs read access to checkout repository contents.
@@ -46,19 +44,18 @@ jobs:
         with:
           go-version: 'stable'    # Always use the latest stable version of Go.
 
-      - name: Install Hugo CLI
-        run: |
-          LATEST_TAG=$(gh release view --repo gohugoio/hugo --json tagName -q .tagName)
-          echo "Installing Hugo version $LATEST_TAG"
-          ASSET_NAME="hugo_extended_${LATEST_TAG#v}_linux-amd64.deb"
-          ASSET_URL=$(gh release view "$LATEST_TAG" --repo gohugoio/hugo --json assets -q ".assets[] | select(.name==\"$ASSET_NAME\") | .url")
-          wget -O ${{ runner.temp }}/hugo.deb "$ASSET_URL"
-          sudo dpkg -i ${{ runner.temp }}/hugo.deb
+      # This is a very common community action to install Hugo.
+      # Nonetheless, see <https://gohugo.io/installation/linux/#prerequisites> for manual details.
+      - name: Hugo setup
+        uses: peaceiris/actions-hugo@v3.0.0
+        with:
+          hugo-version: 'latest'  # Always use the latest stable version of Hugo (according to Homebrew).
+          extended: true          # Required for SCSS/SASS support in themes.
 
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: recursive  # Ensures theme assets are available during build.
+          submodules: recursive   # Ensures theme assets are available during build.
 
       - name: Setup GitHub Pages
         id: pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: recursive   # Ensures theme assets are available during build.
           fetch-depth: 0          # Full history is needed for accurate versioning (e.g. .GitInfo, .LastMod, enableGitInfo).
 
       - name: Setup GitHub Pages

--- a/.gitignore
+++ b/.gitignore
@@ -1,23 +1,18 @@
 # This .gitignore is appropriate for repositories deployed to GitHub Pages and using
-# a Gemfile as specified at https://github.com/github/pages-gem#conventional
-
-# Basic Jekyll gitignores (synchronize to Jekyll.gitignore)
-_site/
-.sass-cache/
-.jekyll-cache/
-.jekyll-metadata
-
-# Additional Ruby/bundler ignore for when you run: bundle install
-/vendor
-
-# Specific ignore for GitHub Pages
-# GitHub Pages will always use its own deployed version of pages-gem 
-# This means GitHub Pages will NOT use your Gemfile.lock and therefore it is
-# counterproductive to check this file into the repository.
-# Details at https://github.com/github/pages-gem/issues/768
-Gemfile.lock
+# Hugo as the static-site generator.
+#
+# See <https://github.com/github/gitignore/blob/main/community/Golang/Hugo.gitignore>.
 
 # IDE-specific files
 # These directories contain editor configurations and should not be committed
 .idea/
 .vscode/
+
+# Generated files by hugo
+/public/
+/resources/_gen/
+/assets/jsconfig.json
+hugo_stats.json
+
+# Temporary lock file while building
+/.hugo_build.lock

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,0 +1,5 @@
+---
+date: '{{ .Date }}'
+draft: true
+title: '{{ replace .File.ContentBaseName "-" " " | title }}'
+---

--- a/docs/decisions/07-hugo-modules-for-themes.md
+++ b/docs/decisions/07-hugo-modules-for-themes.md
@@ -1,0 +1,66 @@
+# Manage Themes Using Hugo Modules
+
+When setting up the foundation for our blog, we faced a critical decision: how should we integrate external themes and
+dependencies? Hugo offers multiple approaches, and while they all work, the choice has a big impact on how smooth (or
+painful) future updates and customisations become. We needed something that wouldn't feel like an obstacle course every
+time we wanted to tweak or upgrade our design.
+
+## Context
+
+Initially, we had two solid options:
+
+- **Git Submodules:** A classic Git feature where you embed another repository within your own. Git-native, but
+  notorious for its confusion and clumsiness.
+- **Hugo Modules:** A Hugo-native dependency system based on Go modules. It provides clean version management, easy
+  updates, and built-in tooling from Hugo itself. However, it requires Go installed on our machines and some familiarity
+  with Go-based workflows.
+
+We considered:
+
+- Ease of use and clarity for authors, especially for the current team composition.
+- Smooth dependency upgrades without manual overhead.
+- Keeping our blog project friendly and low-maintenance in the long run.
+
+## Decision
+
+We chose to manage our Hugo themes and other dependencies using **Hugo Modules**.
+
+We haven't yet decided if we will vendor modules (`hugo mod vendor`) or keep fetching them live. Both options are
+viable, and the decision will be based on practical experience as we move forward.
+
+### Rationale
+
+- **Cleaner Dependency Management:** Updates are as simple as editing the config file and running a quick command. No
+  Git wrangling required.
+- **Consistency with Hugo Ecosystem:** Embracing Hugo modules keeps our tooling consistent with Hugo-native workflows.
+- **Flexibility for Growth:** Modules allow us to easily integrate not just themes, but other reusable content or
+  shortcodes if our needs expand.
+
+## Consequences
+
+- We benefit from reduced Git friction, saving maintainers from manual submodule headaches.
+- Authors need Go installed locally, unless we vendor our modules using `hugo mod vendor`.
+- Slight learning curve for anyone unfamiliar with Go modules.
+- Future maintainers unfamiliar with Hugo Modules can start with the [official Hugo Modules documentation][hugo-mod] for
+  clear and practical guidance.
+
+[hugo-mod]: https://gohugo.io/hugo-modules
+
+### Common Workflows
+
+- Update all theme modules to latest versions:
+  ```shell
+  hugo mod get -u
+  ```
+
+- Require a new theme:
+  ```shell
+  hugo mod get github.com/example/new-theme
+  ```
+
+## Revisit When
+
+- Team-wide adoption of Go tools becomes cumbersome or impractical due to changes in our team's composition or toolset
+  preferences.
+- Hugo introduces a simpler, Hugo-native solution that entirely replaces the advantages of modules.
+

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -44,3 +44,4 @@ This section should be updated whenever a new decision file is added:
 4. [GitHub Pages for Blog Hosting (Initially)](./04-hosting-on-github-pages.md)
 5. [Enforce Consistent Writing Style with Vale](./05-style-linting-with-vale.md)
 6. [Publish Continuously from the `main` Branch (with Meaningful Release Tags)](./06-publishing-continuously.md)
+7. [Manage Themes Using Hugo Modules](./07-hugo-modules-for-themes.md)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/bytes-of-our-lives/blog
 
 go 1.24.2
+
+require github.com/spf13/hyde v1.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/bytes-of-our-lives/blog
+
+go 1.24.2

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/spf13/hyde v1.3.0 h1:7zf9f7xxMfD5KwdrJU+V2w7yi1W8dKKyzvNtQkuh0sE=
+github.com/spf13/hyde v1.3.0/go.mod h1:CSmLWCbXXInaA5zAkwAQ0EbwpR7Pe74eSmDxdGspoCY=

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,3 +1,7 @@
 baseURL: https://example.org/
 languageCode: en-us
 title: "Bytes of our Lives 👾"
+
+module:
+  imports:
+    - path: github.com/spf13/hyde

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,0 +1,3 @@
+baseURL: https://example.org/
+languageCode: en-us
+title: "Bytes of our Lives 👾"

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -6,7 +6,8 @@
 title: "Bytes of our Lives 👾"
 
 # The absolute URL of your published site including the protocol, host, path, and a trailing slash.
-baseURL: https://example.org/
+# Uncomment when using a custom domain.
+# baseURL: https://example.org/
 
 # The site’s language tag, conforming to the syntax described in RFC 5646.
 languageCode: en-us

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,7 +1,17 @@
-baseURL: https://example.org/
-languageCode: en-us
+# Hugo configuration file
+#
+# See all settings at <https://gohugo.io/configuration/all/>.
+
+# The title of your site, displayed in the browser title bar and header.
 title: "Bytes of our Lives 👾"
 
+# The absolute URL of your published site including the protocol, host, path, and a trailing slash.
+baseURL: https://example.org/
+
+# The site’s language tag, conforming to the syntax described in RFC 5646.
+languageCode: en-us
+
+# Configure modules (themes, plugins, etc.) for Hugo.
 module:
   imports:
     - path: github.com/spf13/hyde


### PR DESCRIPTION
This pull request introduces the first revision of our Hugo-based blog, including:
- Automated deployment to GitHub Pages
- Theme management (based on Hugo Modules)
- Sane default for essential configuration files
- A simple theme (based on Jekyll)

While reviewing this changeset, refer to:
- [Hugo directory structure](https://gohugo.io/getting-started/directory-structure/)
- [Getting started with Hugo](https://gohugo.io/getting-started/)
- [Hugo configuration reference](https://gohugo.io/configuration/)
- [Hugo themes for blogs](https://themes.gohugo.io/tags/blog/)
- [Explanation of Hugo's content management](https://gohugo.io/content-management/)
- [Explanation of the default archetype](https://gohugo.io/content-management/archetypes/)
- [Hugo modules reference](https://gohugo.io/hugo-modules/)
- [Hyde theme](https://github.com/spf13/hyde)

Proof: <https://github.com/bytes-of-our-lives/blog/pull/9#issuecomment-2927425149>
Resolves: #2 #7